### PR TITLE
Use crc32c when crc32 is received.

### DIFF
--- a/src/client/LocalBlockReader.cpp
+++ b/src/client/LocalBlockReader.cpp
@@ -82,10 +82,6 @@ LocalBlockReader::LocalBlockReader(const shared_ptr<ReadShortCircuitInfo>& info,
             break;
 
         case ChecksumTypeProto::CHECKSUM_CRC32:
-            THROW(HdfsIOException,
-                  "LocalBlockReader does not support CRC32 checksum.");
-            break;
-
         case ChecksumTypeProto::CHECKSUM_CRC32C:
             if (HWCrc32c::available()) {
                 checksum = shared_ptr<Checksum>(new HWCrc32c());

--- a/src/client/RemoteBlockReader.cpp
+++ b/src/client/RemoteBlockReader.cpp
@@ -152,10 +152,6 @@ void RemoteBlockReader::checkResponse() {
         break;
 
     case ChecksumTypeProto::CHECKSUM_CRC32:
-        THROW(HdfsIOException, "RemoteBlockReader does not support CRC32 checksum, Block: %s, from Datanode: %s",
-              binfo.toString().c_str(), datanode.formatAddress().c_str());
-        break;
-
     case ChecksumTypeProto::CHECKSUM_CRC32C:
         if (HWCrc32c::available()) {
             checksum = shared_ptr<Checksum>(new HWCrc32c());


### PR DESCRIPTION
libhdfs3 doesn't know how to handle CRC32 due to unknown reason. Let's just use CRC32C instead and fail when checksum will be different. This allows no-checksum setup to work as expected.