### PR TITLE
fix code range related to the cpu architure.

### DIFF
--- a/src/common/HWCrc32c.cpp
+++ b/src/common/HWCrc32c.cpp
@@ -70,6 +70,7 @@ static inline uint32_t _mm_crc32_u8(uint32_t crc, uint8_t value) {
 #include <nmmintrin.h>
 
 #endif
+#endif
 
 namespace Hdfs {
 namespace Internal {
@@ -161,5 +162,3 @@ void HWCrc32c::updateInt64(const char * b, int len) {
 
 }
 }
-
-#endif /* _HDFS_LIBHDFS3_COMMON_HWCHECKSUM_H_ */


### PR DESCRIPTION
   When I found that when using a machine with a non-X86 architecture to build clickhouse, the codes of HWCrc32.h and HWCrc32.cpp were not unified. The code of the CPU architecture was not included in .h, but the definition of X86 only covered in .cpp. At the end of the document, this is unreasonable, please take the time to have a look.