### PR TITLE
Remove harmful function

### DIFF
--- a/src/client/FileSystemImpl.cpp
+++ b/src/client/FileSystemImpl.cpp
@@ -110,8 +110,7 @@ FileSystemImpl::FileSystemImpl(const FileSystemKey& key, const Config& c)
     static atomic<uint32_t> count(0);
     std::stringstream ss;
     ss.imbue(std::locale::classic());
-    srand((unsigned int) time(NULL));
-    ss << "libhdfs3_client_random_" << rand() << "_count_" << ++count << "_pid_"
+    ss << "libhdfs3_client_count_" << ++count << "_pid_"
        << getpid() << "_tid_" << pthread_self();
     clientName = ss.str();
     workingDir = std::string("/user/") + user.getEffectiveUser();


### PR DESCRIPTION
To be able to run integration tests in debug. Also I think this rand() is not really needed there since we already add pid and static atomic counter.