### PR TITLE
Remove permission length check

### DIFF
--- a/src/client/Permission.cpp
+++ b/src/client/Permission.cpp
@@ -33,12 +33,6 @@
 namespace Hdfs {
 
 Permission::Permission(uint16_t mode) {
-    if (mode >> 10) {
-        THROW(InvalidParameter,
-              "Invalid parameter: cannot convert %u to \"Permission\"",
-              static_cast<unsigned int>(mode));
-    }
-
     userAction = (Action)((mode >> 6) & 7);
     groupAction = (Action)((mode >> 3) & 7);
     otherAction = (Action)(mode & 7);


### PR DESCRIPTION
In some Hadoop clusters, users enable some extensions, such as ACLs.
![image](https://user-images.githubusercontent.com/16730247/149864003-fecc8813-a301-4f2b-9402-6008abb9d160.png)
At this time, libhdfs will report an error, which cannot be bypassed without modifying the cluster configuration.

![image](https://user-images.githubusercontent.com/16730247/149864325-d828711e-d51e-47e8-981f-c5c592e0a237.png)
Similar checks are not done in hadoop code